### PR TITLE
Llms.txt documentation files

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,123 @@
+# PromptPerfect
+> Open-source prompt optimization tool that automatically improves your LLM prompts and explains the changes. Supports GPT-4, Claude, and Gemini. Bring your own API key — it never leaves your browser.
+
+## Documentation
+- [Try PromptPerfect](https://promptperfect-xyz.vercel.app): Use it in your browser — no install needed
+- [GitHub](https://github.com/Beagle-AI-automation/promptperfect): Source code, setup instructions, contributing guide
+- [API Route](https://github.com/Beagle-AI-automation/promptperfect#api): POST /api/optimize endpoint docs
+
+## Optimization Modes
+- **Better**: General-purpose prompt improvement with explanations
+- **Specific**: Adds constraints, types, edge cases for technical prompts
+- **Chain-of-Thought**: Restructures prompts for step-by-step reasoning
+
+## Tech Stack
+- Next.js 14 (App Router)
+- Vercel AI SDK (streaming)
+- Tailwind CSS + shadcn/ui
+- Supabase (feedback tracking)
+- TypeScript
+
+# PromptPerfect
+
+> PromptPerfect is an open-source prompt optimization tool that automatically improves your LLM prompts and explains the changes.
+
+<img width="1899" height="912" alt="image" src="https://github.com/user-attachments/assets/79d8f61d-aab4-4f0d-a81f-85c2de4d75b8" />
+<img width="1902" height="890" alt="image" src="https://github.com/user-attachments/assets/f4af916b-ab2a-437f-8034-26e2c3c3e73e" />
+
+
+PromptPerfect takes your draft prompts—whether vague, messy, or just a rough idea—and transforms them into high-quality, engineered prompts using AI. It doesn't just rewrite them; it teaches you *why* the changes were made, helping you become a better prompt engineer over time. Choose from modes like "Make it Better," "Make it Specific," or "Add Chain-of-Thought" to get exactly the result you need.
+
+## Features
+
+- **Instant Optimization**: Turn simple phrases into professional prompts in seconds.
+- **Detailed Explanations**: Learn the "why" behind every change with educational breakdowns.
+- **Multiple Modes**:
+  - **Better**: General improvement for clarity and robustness.
+  - **Specific**: Adds constraints and details to reduce hallucinations.
+  - **Chain-of-Thought**: Structures the prompt to encourage step-by-step reasoning.
+- **Privacy-First**: Your API keys are stored locally in your browser and never saved to our servers.
+- **Open Source**: Built with modern web technologies, free to use and extend.
+
+## Tech Stack
+
+| Component | Technology |
+| :--- | :--- |
+| **Framework** | Next.js 14 (App Router) |
+| **Language** | TypeScript |
+| **Styling** | Tailwind CSS + shadcn/ui |
+| **AI Integration** | Vercel AI SDK |
+| **Icons** | Lucide React |
+| **Database** | Supabase (for analytics) |
+| **Deployment** | Vercel |
+
+## Getting Started
+
+Follow these steps to run PromptPerfect locally on your machine.
+
+### Prerequisites
+
+- Node.js 18+ installed
+- A Google Gemini API key (or OpenAI/Anthropic key for BYOK)
+
+### Installation
+
+1.  **Clone the repository:**
+
+    ```bash
+    git clone https://github.com/Beagle-AI-automation/promptperfect.git
+    cd promptperfect
+    ```
+
+2.  **Install dependencies:**
+
+    ```bash
+    npm install
+    ```
+
+3.  **Configure environment variables:**
+
+    Create a `.env.local` file in the root directory and add your API keys:
+
+    ```env
+    # Required for default provider
+    GOOGLE_API_KEY=your_gemini_api_key_here
+
+    # Optional: For analytics (Supabase)
+    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+    ```
+
+4.  **Run the development server:**
+
+    ```bash
+    npm run dev
+    ```
+
+    Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Deploy Your Own
+
+You can deploy your own instance of PromptPerfect to Vercel with a single click:
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/Beagle-AI-automation/promptperfect&env=GOOGLE_API_KEY&envDescription=Get%20a%20Gemini%20API%20key%20from%20ai.google.dev)
+
+## Contributing
+
+We welcome contributions! Whether it's fixing bugs, improving documentation, or suggesting new features, your help is appreciated.
+
+1.  Fork the repository.
+2.  Create a new branch (`git checkout -b feature/amazing-feature`).
+3.  Commit your changes (`git commit -m 'Add some amazing feature'`).
+4.  Push to the branch (`git push origin feature/amazing-feature`).
+5.  Open a Pull Request.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+---
+
+<p align="center">
+  Built by the <a href="https://github.com/Beagle-AI-automation">Beagle Builder Program</a>
+</p>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,19 @@
+# PromptPerfect
+> Open-source prompt optimization tool that automatically improves your LLM prompts and explains the changes. Supports GPT-4, Claude, and Gemini. Bring your own API key — it never leaves your browser.
+
+## Documentation
+- [Try PromptPerfect](https://promptperfect-xyz.vercel.app): Use it in your browser — no install needed
+- [GitHub](https://github.com/Beagle-AI-automation/promptperfect): Source code, setup instructions, contributing guide
+- [API Route](https://github.com/Beagle-AI-automation/promptperfect#api): POST /api/optimize endpoint docs
+
+## Optimization Modes
+- **Better**: General-purpose prompt improvement with explanations
+- **Specific**: Adds constraints, types, edge cases for technical prompts
+- **Chain-of-Thought**: Restructures prompts for step-by-step reasoning
+
+## Tech Stack
+- Next.js 14 (App Router)
+- Vercel AI SDK (streaming)
+- Tailwind CSS + shadcn/ui
+- Supabase (feedback tracking)
+- TypeScript


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What I Built
Created `llms.txt` and `llms-full.txt` in the project root to provide AI assistants (like Cursor's `@Docs` feature) with project context.

- `llms.txt`: Contains a concise, spec-compliant description of the project for AI models.
- `llms-full.txt`: Includes the content of `llms.txt` followed by the full `README.md`, offering complete project context.

## How to Test
1.  Verify that `llms.txt` and `llms-full.txt` exist in the project root.
2.  Confirm `llms.txt` content matches the provided specification (title, summary, documentation, optimization modes, tech stack).
3.  Confirm `llms-full.txt` content starts with the exact `llms.txt` content, immediately followed by the full `README.md` content.
4.  Ensure both files are plain markdown, without frontmatter or surrounding code fences.

## Screenshots
N/A

## Checklist
- [x] Tests pass locally (`npm test` or `pytest`)
- [x] No hardcoded API keys or secrets
- [x] Commit messages follow conventional format (feat:/fix:/test:/docs:)
- [ ] Posted PR link in team Discord channel

---
<p><a href="https://cursor.com/agents/bc-4cf16863-9090-4c0c-ae1f-7b79adc3bac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf16863-9090-4c0c-ae1f-7b79adc3bac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->