### PR TITLE
 Extract Supabase URL retrieval into a separate function

### DIFF
--- a/src/lib/client/supabase.ts
+++ b/src/lib/client/supabase.ts
@@ -3,10 +3,18 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 let cached: SupabaseClient | null = null;
 let adminCached: SupabaseClient | null = null;
 
+function getSupabaseUrl(): string | null {
+  return (
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()?.replace(/\/$/, '') ||
+    process.env.SUPABASE_URL?.trim()?.replace(/\/$/, '') ||
+    null
+  );
+}
+
 export function getSupabaseClient(): SupabaseClient | null {
   if (cached) return cached;
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const url = getSupabaseUrl();
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
   if (!url || !anonKey) return null;
 
@@ -18,7 +26,7 @@ export function getSupabaseClient(): SupabaseClient | null {
 export function getSupabaseAdminClient(): SupabaseClient | null {
   if (adminCached) return adminCached;
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const url = getSupabaseUrl();
   const serviceRoleKey =
     process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() ||
     process.env.SUPABASE_SERVICE_KEY?.trim();


### PR DESCRIPTION
- Introduced getSupabaseUrl function to streamline URL fetching logic.
- Updated getSupabaseClient and getSupabaseAdminClient to use the new function for improved readability and maintainability.

## What I Built
[Brief description of the feature or fix]

## How to Test
[Step-by-step instructions to test this PR locally]

## Screenshots
[If UI changes, add before/after screenshots]

## Checklist
- [ ] Tests pass locally (`npm test` or `pytest`)
- [ ] No hardcoded API keys or secrets
- [ ] Commit messages follow conventional format (feat:/fix:/test:/docs:)
- [ ] Posted PR link in team Discord channel
