### PR TITLE
Improve password reset, extension BYOK, and docs hydration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 # Local dev: http://localhost:3000 (add these Redirect URLs in Supabase → Authentication → URL Configuration):
 #   http://localhost:3000/auth/callback
 #   http://localhost:3000/auth/reset
+# Password reset emails fail until /auth/reset is allowlisted and SUPABASE_SERVICE_ROLE_KEY is in .env.local
 # Production: https://<your-domain>/auth/callback and https://<your-domain>/auth/reset
 #
 # Google OAuth (fixes "Error getting user profile from external provider"):

--- a/extension/README.md
+++ b/extension/README.md
@@ -2,7 +2,9 @@
 
 Inject an **✨ Optimize** button into any text field on the page (ChatGPT, Gmail, Notion, etc.). One click sends the text to your PromptPerfect API and replaces the field with the optimized prompt.
 
-**Default API URL:** `https://promptperfect.vercel.app` (change in the extension popup for self‑hosted or local dev).
+**Default API URL:** `https://promptperfect-beaglecorp.vercel.app` (change in the extension popup for self‑hosted or local dev).
+
+**API key required:** The extension uses BYOK (your Gemini / OpenAI / Anthropic key). Web-app sign-in does not apply inside the extension.
 
 ---
 
@@ -43,9 +45,10 @@ Add images under `extension/screenshots/` and reference them in the Web Store li
 
 5. **First-time settings**  
    - Click the PromptPerfect icon in the toolbar  
-   - **API URL** should default to `https://promptperfect.vercel.app`  
-   - For a local app, set to `http://localhost:3000` (or your dev URL) and click **Save**  
-   - Status should show **Connected** if the API is reachable
+   - **API URL** should default to `https://promptperfect-beaglecorp.vercel.app`  
+   - Choose **Provider** and paste your **API key** (required)  
+   - For a local app, set API URL to `http://localhost:3000` and click **Save**  
+   - Status should show **API reachable** if the server responds
 
 6. **Reload after code changes**  
    - On `chrome://extensions`, click **Reload** on the PromptPerfect card whenever you change files in `extension/`
@@ -97,7 +100,7 @@ Theme: `#050505` backgrounds in popup, **`#4552FF`** accent — matches the web 
 Run through these steps after every `Load unpacked` reload.
 
 1. **Load unpacked** — `chrome://extensions` → Developer mode → Load unpacked → select `extension/` (the folder containing `manifest.json`). Extension card appears with no errors.
-2. **Settings check** — Click the extension icon → expand **⚙ Settings** → confirm API URL defaults to `https://promptperfect.vercel.app` → **✅ Connected** appears. Optionally paste a BYOK key and Save.
+2. **Settings check** — Click the extension icon → expand **⚙ Settings** → confirm API URL → paste API key + provider → **Save** → **✅ API reachable · key saved**.
 3. **Popup optimize** — In the popup, paste any prompt into the **Prompt** textarea → **✨ Optimize** button enables → click it → optimized result appears in the **Result** box within 10 s.
 4. **Stateless check** — Close the popup, reopen it → textarea is empty, result is gone, no history panel visible.
 5. **On-page button** — Focus any text field on ChatGPT / Gmail / Notion → **✨ Optimize** button appears below it → click → spinner shows → result replaces the field text + green toast.
@@ -108,8 +111,11 @@ Run through these steps after every `Load unpacked` reload.
 
 | Issue | What to try |
 |-------|----------------|
+| `401` / sign in message | Add your **API key** in Settings — extension cannot use web login |
+| Provider mismatch | Gemini key → Provider **Gemini**; same for OpenAI / Anthropic |
 | Optimize does nothing | Check API URL and **Reload** extension after changing settings |
-| Not connected | API must expose `/api/optimize-sync` with CORS (included in PromptPerfect app) |
+| Not connected | API must expose `/api/config` and `/api/optimize-sync` (included in PromptPerfect app) |
+| Button missing on a site | Extension only runs on ChatGPT, Gmail, Docs, Notion, X, and localhost — see `manifest.json` |
 | Wrong project | Ensure **API URL** matches where the app is deployed |
 
 ## Files

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -2,7 +2,29 @@
 
 const DEFAULT_API_URL = 'https://promptperfect-beaglecorp.vercel.app';
 const DEFAULT_MODE = 'better';
+const DEFAULT_PROVIDER = 'gemini';
 const FETCH_TIMEOUT_MS = 30_000;
+
+function friendlyApiError(status, data) {
+  const msg =
+    (typeof data?.error === 'string' && data.error) ||
+    (typeof data?.message === 'string' && data.message) ||
+    '';
+
+  if (status === 401) {
+    return (
+      'Add your API key in extension Settings (⚙). ' +
+      'The extension cannot use your web login — BYOK is required.'
+    );
+  }
+  if (status === 429) {
+    return msg || 'Too many requests — wait a minute and try again.';
+  }
+  if (status === 400 && msg) {
+    return msg;
+  }
+  return msg || `Request failed (${status})`;
+}
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type !== 'OPTIMIZE') return false;
@@ -11,15 +33,15 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     const settings = await chrome.storage.sync.get({
       apiUrl: DEFAULT_API_URL,
       mode: DEFAULT_MODE,
+      provider: DEFAULT_PROVIDER,
       apiKey: '',
     });
+
     const apiUrl =
       typeof settings.apiUrl === 'string' && settings.apiUrl.trim()
         ? settings.apiUrl.trim().replace(/\/$/, '')
         : DEFAULT_API_URL;
 
-    // Prefer mode sent by the popup (live dropdown value) over the stored setting.
-    // Fall back to stored mode for content-script calls that don't send one.
     const mode =
       typeof message.mode === 'string' && message.mode.trim()
         ? message.mode.trim()
@@ -27,15 +49,36 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           ? settings.mode.trim()
           : DEFAULT_MODE;
 
+    const provider =
+      typeof message.provider === 'string' && message.provider.trim()
+        ? message.provider.trim()
+        : typeof settings.provider === 'string' && settings.provider.trim()
+          ? settings.provider.trim()
+          : DEFAULT_PROVIDER;
+
     const apiKey =
       typeof settings.apiKey === 'string' ? settings.apiKey.trim() : '';
 
-    const url = `${apiUrl}/api/optimize-sync`;
-    const body = { prompt: message.text, mode };
-    const headers = { 'Content-Type': 'application/json' };
-    if (apiKey) {
-      headers.Authorization = `Bearer ${apiKey}`;
+    if (!apiKey) {
+      return {
+        error:
+          'No API key saved. Open extension Settings (⚙), paste your Gemini / OpenAI / Anthropic key, choose provider, and click Save.',
+        code: 'MISSING_API_KEY',
+      };
     }
+
+    const url = `${apiUrl}/api/optimize-sync`;
+    const body = {
+      prompt: message.text,
+      text: message.text,
+      mode,
+      provider,
+      apiKey,
+    };
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    };
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -48,30 +91,41 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         signal: controller.signal,
       });
       clearTimeout(timeoutId);
+
       let data = {};
       try {
         data = await res.json();
       } catch {
         data = {};
       }
+
       if (!res.ok) {
+        return { error: friendlyApiError(res.status, data), code: 'API_ERROR' };
+      }
+
+      const optimizedText =
+        (typeof data.optimizedText === 'string' && data.optimizedText) ||
+        (typeof data.result === 'string' && data.result) ||
+        '';
+
+      if (!optimizedText.trim()) {
         return {
-          error:
-            data.error ||
-            data.message ||
-            `Request failed (${res.status})`,
+          error: 'Empty response from API — check API URL and provider match your key.',
+          code: 'EMPTY_RESPONSE',
         };
       }
-      return data;
+
+      return { optimizedText: optimizedText.trim(), ...data };
     } catch (err) {
       clearTimeout(timeoutId);
       const isTimeout = err instanceof Error && err.name === 'AbortError';
       return {
         error: isTimeout
-          ? 'Request timed out — check your API URL or connection'
+          ? 'Request timed out — check API URL (use http://localhost:3000 for local dev)'
           : err instanceof Error
             ? err.message
-            : 'Network error — check API URL',
+            : 'Network error — check API URL and reload the extension',
+        code: 'NETWORK_ERROR',
       };
     }
   })()
@@ -79,6 +133,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     .catch((e) =>
       sendResponse({
         error: e instanceof Error ? e.message : 'Optimization failed',
+        code: 'WORKER_ERROR',
       }),
     );
 

--- a/extension/content/universal.js
+++ b/extension/content/universal.js
@@ -1,6 +1,20 @@
 (function () {
   'use strict';
 
+  if (
+    typeof chrome === 'undefined' ||
+    !chrome.runtime?.id ||
+    location.protocol === 'chrome:' ||
+    location.protocol === 'chrome-extension:' ||
+    location.protocol === 'about:'
+  ) {
+    return;
+  }
+
+  if (/\/docs(\/|$)/.test(location.pathname)) {
+    return;
+  }
+
   const BUTTON_ID = 'pp-optimize-btn';
   let hideTimeout = null;
   let currentTarget = null;
@@ -8,11 +22,47 @@
 
   function isTextInput(el) {
     if (!el || !el.tagName) return false;
+    if (el.disabled || el.readOnly) return false;
     const tag = el.tagName.toLowerCase();
     const type = (el.type || '').toLowerCase();
+    const autocomplete = (el.getAttribute('autocomplete') || '').toLowerCase();
+    if (autocomplete.includes('password') || autocomplete.startsWith('cc-')) {
+      return false;
+    }
     if (tag === 'textarea') return true;
-    if (tag === 'input' && (type === 'text' || type === 'search' || type === 'email' || type === 'url'))
+    if (
+      tag === 'input' &&
+      (type === 'text' ||
+        type === 'search' ||
+        type === 'email' ||
+        type === 'url' ||
+        type === '')
+    ) {
       return true;
+    }
+    if (tag === 'input') {
+      const skipTypes = [
+        'password',
+        'hidden',
+        'checkbox',
+        'radio',
+        'file',
+        'submit',
+        'button',
+        'reset',
+        'number',
+        'tel',
+        'date',
+        'time',
+        'datetime-local',
+        'month',
+        'week',
+        'color',
+        'range',
+      ];
+      if (skipTypes.includes(type)) return false;
+      return false;
+    }
     if (el.isContentEditable) return true;
     return false;
   }
@@ -180,7 +230,10 @@
         const response = await sendOptimizeMessage(text.trim());
 
         if (response && response.error) {
-          showNotification('Optimization failed: ' + response.error, 'error');
+          const errText = String(response.error);
+          const short =
+            errText.length > 120 ? errText.slice(0, 117) + '…' : errText;
+          showNotification(short, 'error');
           return;
         }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
   "name": "PromptPerfect — AI Prompt Optimizer",
-  "version": "1.1.0",
-  "description": "Optimize your prompts anywhere with one click",
+  "version": "1.2.0",
+  "description": "Optimize your prompts on ChatGPT, Gmail, Notion, and more with one click",
   "permissions": ["activeTab", "storage"],
-  "host_permissions": ["http://*/*", "https://*/*"],
+  "host_permissions": ["http://localhost/*", "https://*/*"],
   "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {
@@ -15,9 +15,28 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*",
+        "https://mail.google.com/*",
+        "https://docs.google.com/*",
+        "https://www.notion.so/*",
+        "https://notion.so/*",
+        "https://twitter.com/*",
+        "https://x.com/*",
+        "https://promptperfect.vercel.app/*",
+        "https://promptperfect-beaglecorp.vercel.app/*",
+        "http://localhost/*",
+        "http://127.0.0.1/*"
+      ],
+      "exclude_matches": [
+        "chrome://*/*",
+        "chrome-extension://*/*",
+        "https://chrome.google.com/*"
+      ],
       "js": ["content/universal.js"],
-      "css": ["styles/button.css"]
+      "css": ["styles/button.css"],
+      "run_at": "document_idle"
     }
   ],
   "background": {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -205,6 +205,17 @@
     }
     #connStatus.connected { color: #22c55e; }
     #connStatus.disconnected { color: #ef4444; }
+    #apiKeyHint {
+      margin: 0 0 10px;
+      padding: 8px 10px;
+      border-radius: 8px;
+      background: #1a1408;
+      border: 1px solid #422006;
+      color: #fbbf24;
+      font-size: 11px;
+      line-height: 1.45;
+    }
+    #apiKeyHint[hidden] { display: none; }
 
     /* ── Footer ── */
     footer {
@@ -264,10 +275,19 @@
   <details id="settingsPanel">
     <summary>⚙ Settings</summary>
     <div class="settings-body">
+      <p id="apiKeyHint" hidden>
+        Add your Gemini, OpenAI, or Anthropic API key below — the extension cannot use web-app sign-in.
+      </p>
       <label for="apiUrl">API URL</label>
       <input type="text" id="apiUrl" placeholder="https://promptperfect-beaglecorp.vercel.app" />
-      <label for="apiKey">API Key <span style="color:#52525b;font-weight:400">(BYOK — optional)</span></label>
-      <input type="password" id="apiKey" placeholder="Leave empty to use default Gemini" />
+      <label for="provider">Provider</label>
+      <select id="provider" aria-label="API provider">
+        <option value="gemini">Gemini</option>
+        <option value="openai">OpenAI</option>
+        <option value="anthropic">Anthropic</option>
+      </select>
+      <label for="apiKey">API key <span style="color:#52525b;font-weight:400">(required)</span></label>
+      <input type="password" id="apiKey" placeholder="Paste your provider API key" autocomplete="off" />
       <button type="button" id="save">Save settings</button>
       <p id="connStatus"></p>
     </div>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -2,63 +2,85 @@
 
 const DEFAULT_API_URL = 'https://promptperfect-beaglecorp.vercel.app';
 
-// ── Element refs ──────────────────────────────────────────────────────────────
-const promptInput    = document.getElementById('promptInput');
-const modeEl         = document.getElementById('mode');
-const optimizeBtn    = document.getElementById('optimizeBtn');
+const promptInput = document.getElementById('promptInput');
+const modeEl = document.getElementById('mode');
+const optimizeBtn = document.getElementById('optimizeBtn');
 const optimizeStatus = document.getElementById('optimizeStatus');
-const resultSection  = document.getElementById('resultSection');
-const resultOutput   = document.getElementById('resultOutput');
-const copyBtn        = document.getElementById('copyBtn');
+const resultSection = document.getElementById('resultSection');
+const resultOutput = document.getElementById('resultOutput');
+const copyBtn = document.getElementById('copyBtn');
 
-const apiUrlEl   = document.getElementById('apiUrl');
-const apiKeyEl   = document.getElementById('apiKey');
-const saveBtn    = document.getElementById('save');
+const apiUrlEl = document.getElementById('apiUrl');
+const providerEl = document.getElementById('provider');
+const apiKeyEl = document.getElementById('apiKey');
+const apiKeyHint = document.getElementById('apiKeyHint');
+const saveBtn = document.getElementById('save');
 const connStatus = document.getElementById('connStatus');
+const settingsPanel = document.getElementById('settingsPanel');
 
-const versionEl  = document.getElementById('ext-version');
-const linkAppEl  = document.getElementById('link-app');
+const versionEl = document.getElementById('ext-version');
+const linkAppEl = document.getElementById('link-app');
 const linkDocsEl = document.getElementById('link-docs');
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
 function originFromUrl(raw) {
   const s = (raw || DEFAULT_API_URL).trim().replace(/\/$/, '');
-  try { return new URL(s).origin; } catch { return DEFAULT_API_URL; }
+  try {
+    return new URL(s).origin;
+  } catch {
+    return DEFAULT_API_URL;
+  }
 }
 
 function updateDocLinks(apiUrlValue) {
   const origin = originFromUrl(apiUrlValue);
-  linkAppEl.href  = origin + '/';
+  linkAppEl.href = origin + '/';
   linkDocsEl.href = origin + '/docs';
 }
 
 function setOptimizeStatus(msg, isError) {
   optimizeStatus.textContent = msg;
-  optimizeStatus.className   = isError ? 'err' : '';
+  optimizeStatus.className = isError ? 'err' : '';
 }
 
-function setConnStatus(connected) {
-  connStatus.textContent = connected ? '✅ Connected' : '❌ Not connected';
-  connStatus.className   = connected ? 'connected' : 'disconnected';
+function setConnStatus(connected, detail) {
+  if (detail) {
+    connStatus.textContent = detail;
+    connStatus.className = connected ? 'connected' : 'disconnected';
+    return;
+  }
+  connStatus.textContent = connected ? '✅ API reachable' : '❌ API unreachable';
+  connStatus.className = connected ? 'connected' : 'disconnected';
 }
 
-async function checkConnection() {
-  const origin  = originFromUrl(apiUrlEl.value);
-  const pingUrl = origin + '/api/optimize-sync';
-  try {
-    const res = await fetch(pingUrl, { method: 'OPTIONS' });
-    setConnStatus(res.ok || res.status === 204 || res.status === 405);
-  } catch {
-    setConnStatus(false);
+function updateApiKeyHint(hasKey) {
+  if (!apiKeyHint) return;
+  apiKeyHint.hidden = Boolean(hasKey);
+  if (!hasKey && settingsPanel && !settingsPanel.open) {
+    settingsPanel.open = true;
   }
 }
 
-// ── Version badge ─────────────────────────────────────────────────────────────
+async function checkConnection() {
+  const origin = originFromUrl(apiUrlEl.value);
+  try {
+    const res = await fetch(origin + '/api/config', { method: 'GET' });
+    if (!res.ok) {
+      setConnStatus(false);
+      return false;
+    }
+    const hasKey = Boolean((apiKeyEl.value || '').trim());
+    setConnStatus(true, hasKey ? '✅ API reachable · key saved' : '✅ API reachable · add API key');
+    return true;
+  } catch {
+    setConnStatus(false);
+    return false;
+  }
+}
+
 if (versionEl && chrome.runtime?.getManifest) {
   versionEl.textContent = 'v' + chrome.runtime.getManifest().version;
 }
 
-// ── Optimize flow (stateless — nothing written to storage) ────────────────────
 promptInput.addEventListener('input', () => {
   optimizeBtn.disabled = !promptInput.value.trim();
 });
@@ -67,17 +89,27 @@ optimizeBtn.addEventListener('click', async () => {
   const text = promptInput.value.trim();
   if (!text) return;
 
-  optimizeBtn.disabled     = true;
-  optimizeBtn.textContent  = 'Optimizing…';
-  resultSection.hidden     = true;
+  const apiKey = (apiKeyEl.value || '').trim();
+  if (!apiKey) {
+    setOptimizeStatus('❌ Add your API key in Settings (⚙) first.', true);
+    updateApiKeyHint(false);
+    return;
+  }
+
+  optimizeBtn.disabled = true;
+  optimizeBtn.textContent = 'Optimizing…';
+  resultSection.hidden = true;
   setOptimizeStatus('', false);
 
   try {
     const response = await new Promise((resolve, reject) => {
-      // Pass the live dropdown value so the service worker uses it directly,
-      // regardless of what was last saved to storage.
       chrome.runtime.sendMessage(
-        { type: 'OPTIMIZE', text, mode: modeEl.value },
+        {
+          type: 'OPTIMIZE',
+          text,
+          mode: modeEl.value,
+          provider: providerEl.value,
+        },
         (res) => {
           if (chrome.runtime.lastError) {
             reject(new Error(chrome.runtime.lastError.message));
@@ -89,11 +121,14 @@ optimizeBtn.addEventListener('click', async () => {
     });
 
     if (!response) {
-      setOptimizeStatus('No response from service worker — reload the extension.', true);
+      setOptimizeStatus('No response — reload the extension on chrome://extensions.', true);
       return;
     }
     if (response.error) {
       setOptimizeStatus('❌ ' + response.error, true);
+      if (response.code === 'MISSING_API_KEY') {
+        updateApiKeyHint(false);
+      }
       return;
     }
     const optimized = response.optimizedText ?? response.result ?? '';
@@ -101,53 +136,60 @@ optimizeBtn.addEventListener('click', async () => {
       setOptimizeStatus('❌ Empty response from API.', true);
       return;
     }
-    resultOutput.value   = optimized;
+    resultOutput.value = optimized;
     resultSection.hidden = false;
   } catch (err) {
     setOptimizeStatus('❌ ' + (err instanceof Error ? err.message : 'Optimization failed'), true);
   } finally {
-    optimizeBtn.disabled    = !promptInput.value.trim();
+    optimizeBtn.disabled = !promptInput.value.trim();
     optimizeBtn.textContent = '✨ Optimize';
   }
 });
 
-// ── Copy result ───────────────────────────────────────────────────────────────
 copyBtn.addEventListener('click', () => {
-  navigator.clipboard.writeText(resultOutput.value).then(() => {
-    copyBtn.textContent = 'Copied!';
-    setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
-  }).catch(() => {
-    resultOutput.select();
-    document.execCommand('copy');
-    copyBtn.textContent = 'Copied!';
-    setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
-  });
+  navigator.clipboard
+    .writeText(resultOutput.value)
+    .then(() => {
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        copyBtn.textContent = 'Copy';
+      }, 1500);
+    })
+    .catch(() => {
+      resultOutput.select();
+      document.execCommand('copy');
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        copyBtn.textContent = 'Copy';
+      }, 1500);
+    });
 });
 
-// ── Settings ──────────────────────────────────────────────────────────────────
-// Stored: apiUrl (endpoint), mode (optimization mode), apiKey (BYOK).
-// Never stored: prompt text, optimized output, history of any kind.
 saveBtn.addEventListener('click', async () => {
   const apiUrl = (apiUrlEl.value || DEFAULT_API_URL).trim().replace(/\/$/, '');
-  const mode   = modeEl.value;
+  const mode = modeEl.value;
+  const provider = providerEl.value;
   const apiKey = (apiKeyEl.value || '').trim();
-  await chrome.storage.sync.set({ apiUrl, mode, apiKey });
+  await chrome.storage.sync.set({ apiUrl, mode, provider, apiKey });
   updateDocLinks(apiUrl);
+  updateApiKeyHint(Boolean(apiKey));
   connStatus.textContent = 'Saving…';
-  connStatus.className   = '';
+  connStatus.className = '';
   await checkConnection();
 });
 
 apiUrlEl.addEventListener('change', () => updateDocLinks(apiUrlEl.value));
+apiKeyEl.addEventListener('input', () => updateApiKeyHint(Boolean(apiKeyEl.value.trim())));
 
-// ── Boot: load stored settings ────────────────────────────────────────────────
 chrome.storage.sync.get(
-  { apiUrl: DEFAULT_API_URL, mode: 'better', apiKey: '' },
+  { apiUrl: DEFAULT_API_URL, mode: 'better', provider: 'gemini', apiKey: '' },
   (items) => {
     apiUrlEl.value = items.apiUrl || DEFAULT_API_URL;
-    modeEl.value   = items.mode   || 'better';
+    modeEl.value = items.mode || 'better';
+    providerEl.value = items.provider || 'gemini';
     apiKeyEl.value = items.apiKey || '';
     updateDocLinks(apiUrlEl.value);
+    updateApiKeyHint(Boolean(items.apiKey));
     checkConnection();
   },
 );

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,5 +1,8 @@
 import { checkRateLimit } from '@/lib/auth/rateLimit';
-import { getPasswordResetOrigin } from '@/lib/auth/oauthRedirect';
+import {
+  mapPasswordResetEmailError,
+  resolvePasswordResetRedirect,
+} from '@/lib/auth/passwordResetRedirect';
 import { validateEmail } from '@/lib/auth/validation';
 import {
   getSupabaseAdminClient,
@@ -9,11 +12,19 @@ import {
 import { createClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
 
+function isLocalRedirect(redirectTo: string): boolean {
+  try {
+    const host = new URL(redirectTo).hostname;
+    return host === 'localhost' || host === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Sends Supabase password recovery email using a server-built redirect URL
- * (must match Authentication → Redirect URLs). Verifies the email exists in
- * Supabase Auth (`auth.users`) via admin `generateLink` so OAuth-only and
- * email users are included—not only rows in the app user / profile tables.
+ * Password recovery: admin generateLink (verifies user + builds link), then
+ * resetPasswordForEmail (sends mail). On localhost, also returns recoveryLink
+ * when Supabase email is rate-limited or undelivered.
  */
 export async function POST(request: Request) {
   const ip =
@@ -27,9 +38,12 @@ export async function POST(request: Request) {
 
   const body = (await request.json().catch(() => null)) as {
     email?: string;
+    redirectTo?: string;
   } | null;
   const raw = typeof body?.email === 'string' ? body.email.trim() : '';
   const email = raw.toLowerCase();
+  const clientRedirectTo =
+    typeof body?.redirectTo === 'string' ? body.redirectTo.trim() : undefined;
 
   if (!validateEmail(email)) {
     return NextResponse.json({ error: 'Invalid email address' }, { status: 400 });
@@ -49,14 +63,14 @@ export async function POST(request: Request) {
           'Password reset is temporarily unavailable (server configuration).',
         code: 'SERVICE_KEY_REQUIRED',
         hint:
-          'Set SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_KEY so we can verify your account before sending a reset link.',
+          'Set SUPABASE_SERVICE_ROLE_KEY in .env.local (Supabase → Settings → API → service_role secret).',
       },
       { status: 503 },
     );
   }
 
-  const origin = getPasswordResetOrigin(request).replace(/\/$/, '');
-  const redirectTo = `${origin}/auth/reset`;
+  const redirectTo = resolvePasswordResetRedirect(request, clientRedirectTo);
+  const localDev = isLocalRedirect(redirectTo);
 
   const { data: linkData, error: genError } =
     await admin.auth.admin.generateLink({
@@ -77,15 +91,16 @@ export async function POST(request: Request) {
       return NextResponse.json(
         {
           error:
-            'No account exists for this email address. Check spelling or create an account.',
+            'No account exists for this email. Sign up first, or use Continue with Google on the login page if you registered that way.',
           code: 'ACCOUNT_NOT_FOUND',
         },
         { status: 404 },
       );
     }
     console.error('[forgot-password] generateLink error:', genError.message);
+    const mapped = mapPasswordResetEmailError(genError.message, redirectTo);
     return NextResponse.json(
-      { error: 'Could not verify account. Please try again.', code: 'LOOKUP_FAILED' },
+      { error: mapped.error, code: mapped.code },
       { status: 400 },
     );
   }
@@ -94,12 +109,22 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error:
-          'No account exists for this email address. Check spelling or create an account.',
+          'No account exists for this email. Sign up first, or use Continue with Google on the login page.',
         code: 'ACCOUNT_NOT_FOUND',
       },
       { status: 404 },
     );
   }
+
+  const recoveryLink =
+    typeof linkData.properties?.action_link === 'string'
+      ? linkData.properties.action_link
+      : undefined;
+
+  const identities = linkData.user.identities ?? [];
+  const signedUpWithGoogleOnly =
+    identities.length > 0 &&
+    identities.every((i) => i.provider === 'google');
 
   const anon = createClient(url, anonKey, {
     auth: {
@@ -109,25 +134,51 @@ export async function POST(request: Request) {
     },
   });
 
-  const { error } = await anon.auth.resetPasswordForEmail(email, {
+  const { error: emailError } = await anon.auth.resetPasswordForEmail(email, {
     redirectTo,
   });
 
-  if (error) {
-    const msg = error.message?.trim() || '';
-    const lower = msg.toLowerCase();
-    console.error('[forgot-password] resetPasswordForEmail error:', msg);
-    const isRedirectIssue = /redirect|url/i.test(lower);
-    return NextResponse.json(
-      {
-        error: isRedirectIssue
-          ? `Reset email blocked: the redirect URL is not in your Supabase allowlist. Add "${redirectTo}" to Supabase → Authentication → URL Configuration → Redirect URLs.`
-          : 'Could not send reset email. Please try again later.',
-        code: 'RESET_EMAIL_FAILED',
-      },
-      { status: 400 },
-    );
+  if (!emailError) {
+    return NextResponse.json({
+      ok: true,
+      emailSent: true,
+      ...(localDev && recoveryLink ? { recoveryLink } : {}),
+      googleOnlyHint: signedUpWithGoogleOnly
+        ? 'This account uses Google sign-in. You can still set a password from the reset link, or use Continue with Google on the login page.'
+        : undefined,
+    });
   }
 
-  return NextResponse.json({ ok: true });
+  const msg = emailError.message?.trim() || '';
+  console.error('[forgot-password] resetPasswordForEmail error:', msg);
+  const mapped = mapPasswordResetEmailError(msg, redirectTo);
+
+  // Local dev: Supabase rate-limits emails (~1/min) but generateLink still works.
+  // Return the direct recovery link so you can reset without waiting on mail.
+  if (localDev && recoveryLink) {
+    return NextResponse.json({
+      ok: true,
+      emailSent: false,
+      recoveryLink,
+      code: mapped.code,
+      message: mapped.error,
+      googleOnlyHint: signedUpWithGoogleOnly
+        ? 'This account uses Google sign-in. Open the link below to set a password, or use Continue with Google.'
+        : undefined,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      error: mapped.error,
+      code: mapped.code,
+      hint:
+        mapped.code === 'REDIRECT_NOT_ALLOWLISTED'
+          ? `Add "${redirectTo}" in Supabase → Authentication → URL Configuration → Redirect URLs.`
+          : mapped.code === 'EMAIL_RATE_LIMIT'
+            ? 'Wait one minute, then try again. Check spam for an earlier email.'
+            : 'Ask your project admin to enable Auth emails or custom SMTP in Supabase.',
+    },
+    { status: 400 },
+  );
 }

--- a/src/app/auth/reset/page.tsx
+++ b/src/app/auth/reset/page.tsx
@@ -1,61 +1,102 @@
-'use client'
+'use client';
 
-import { useEffect, useMemo, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
-import { validatePassword } from '@/lib/auth/validation'
-import { AuthShell } from '@/components/auth/AuthShell'
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/client/supabaseBrowser';
+import { validatePassword } from '@/lib/auth/validation';
+import { AuthShell } from '@/components/auth/AuthShell';
 import {
   authInputClass,
   authLabelClass,
   authPrimaryBtnClass,
-} from '@/components/auth/auth-styles'
+} from '@/components/auth/auth-styles';
 
 export default function AuthResetPage() {
-  const router = useRouter()
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-  const [success, setSuccess] = useState(false)
+  const router = useRouter();
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(false);
+  const [sessionReady, setSessionReady] = useState(false);
 
-  const supabase = useMemo(() => {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    if (!url || !key) return null
-    return createBrowserClient(url, key)
-  }, [])
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
 
   useEffect(() => {
-    if (!supabase) return
-    void supabase.auth.getSession()
-  }, [supabase])
+    if (!supabase) return;
+
+    let cancelled = false;
+
+    async function initRecoverySession() {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+
+      if (code) {
+        const { error: exchangeErr } =
+          await supabase.auth.exchangeCodeForSession(code);
+        if (!cancelled && exchangeErr) {
+          setError(
+            'This reset link is invalid or expired. Request a new link from the forgot-password page.',
+          );
+          setSessionReady(true);
+          return;
+        }
+      }
+
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!cancelled && !session) {
+        setError(
+          'Open the password reset link from your email in this browser. If it expired, request a new one.',
+        );
+      }
+
+      if (!cancelled) setSessionReady(true);
+    }
+
+    void initRecoverySession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
 
   async function onSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setError('')
+    e.preventDefault();
+    setError('');
     if (!supabase) {
-      setError('Supabase is not configured')
-      return
+      setError('Supabase is not configured');
+      return;
     }
-    const v = validatePassword(password)
+    const v = validatePassword(password);
     if (!v.isValid) {
-      setError(v.errors[0] ?? 'Invalid password')
-      return
+      setError(v.errors[0] ?? 'Invalid password');
+      return;
     }
     if (password !== confirmPassword) {
-      setError('Passwords do not match')
-      return
+      setError('Passwords do not match');
+      return;
     }
-    setLoading(true)
-    const { error: err } = await supabase.auth.updateUser({ password })
-    setLoading(false)
+    setLoading(true);
+    const { error: err } = await supabase.auth.updateUser({ password });
+    setLoading(false);
     if (err) {
-      setError(err.message)
-      return
+      setError(err.message);
+      return;
     }
-    setSuccess(true)
-    setTimeout(() => router.push('/login'), 3000)
+    setSuccess(true);
+    setTimeout(() => router.push('/login'), 3000);
+  }
+
+  if (!sessionReady) {
+    return (
+      <AuthShell>
+        <p className="text-center text-sm text-[#B0B0B0]">Loading reset link…</p>
+      </AuthShell>
+    );
   }
 
   return (
@@ -82,6 +123,7 @@ export default function AuthResetPage() {
                 placeholder="••••••••"
                 autoComplete="new-password"
                 className={authInputClass}
+                disabled={Boolean(error && !password)}
               />
             </div>
             <div>
@@ -97,6 +139,7 @@ export default function AuthResetPage() {
                 placeholder="••••••••"
                 autoComplete="new-password"
                 className={authInputClass}
+                disabled={Boolean(error && !password)}
               />
             </div>
             {error && (
@@ -104,13 +147,22 @@ export default function AuthResetPage() {
                 {error}
               </p>
             )}
-            <button
-              type="submit"
-              disabled={loading}
-              className={authPrimaryBtnClass}
-            >
-              {loading ? 'Updating…' : 'Update password'}
-            </button>
+            {!error || password ? (
+              <button
+                type="submit"
+                disabled={loading}
+                className={authPrimaryBtnClass}
+              >
+                {loading ? 'Updating…' : 'Update password'}
+              </button>
+            ) : (
+              <Link
+                href="/forgot-password"
+                className={`${authPrimaryBtnClass} block text-center no-underline`}
+              >
+                Request a new reset link
+              </Link>
+            )}
           </form>
         </>
       ) : (
@@ -130,5 +182,5 @@ export default function AuthResetPage() {
         </>
       )}
     </AuthShell>
-  )
+  );
 }

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { DocsCodeBlock } from '@/components/DocsCodeBlock';
+
 export const metadata: Metadata = {
   title: 'API Documentation — PromptPerfect by Beagle',
   description:
@@ -8,14 +10,6 @@ export const metadata: Metadata = {
 };
 
 const BASE = 'https://promptperfect-beaglecorp.vercel.app';
-
-function CodeBlock({ children }: { children: string }) {
-  return (
-    <pre className="mt-3 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 p-3 text-left text-[12px] leading-relaxed text-zinc-200 sm:p-4 sm:text-[13px]">
-      <code className="font-mono whitespace-pre">{children}</code>
-    </pre>
-  );
-}
 
 function SectionTitle({
   id,
@@ -198,7 +192,7 @@ export default function DocsPage() {
               Core fields (TypeScript-style). Unknown <code className="rounded bg-zinc-900 px-1 py-0.5">mode</code>{' '}
               values fall back to <code className="rounded bg-zinc-900 px-1 py-0.5">better</code>.
             </p>
-            <CodeBlock>{`{
+            <DocsCodeBlock>{`{
   /** Input prompt (preferred) */
   text: string;
   /** Alias accepted for compatibility */
@@ -208,7 +202,7 @@ export default function DocsPage() {
   apiKey?: string;
   session_id?: string;
   version?: 'v1' | 'v2';
-}`}</CodeBlock>
+}`}</DocsCodeBlock>
 
             <h3 className="mt-10 text-base font-semibold text-[#ECECEC]">Response body (200)</h3>
             <p className="mt-2 text-sm text-zinc-400">
@@ -217,7 +211,7 @@ export default function DocsPage() {
               usually starts with <code className="rounded bg-zinc-900 px-1 py-0.5">&quot;- &quot;</code>
               ). Split on newlines if you need a list. Extra fields help with debugging and logging.
             </p>
-            <CodeBlock>{`{
+            <DocsCodeBlock>{`{
   optimizedText: string;
   explanation: string;
   /** Bullet-style lines joined with newlines (not a JSON array) */
@@ -225,7 +219,7 @@ export default function DocsPage() {
   rawText: string;
   provider: string;
   model: string;
-}`}</CodeBlock>
+}`}</DocsCodeBlock>
 
             <h3 className="mt-10 text-base font-semibold text-[#ECECEC]">Errors</h3>
             <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-zinc-400">
@@ -242,21 +236,21 @@ export default function DocsPage() {
             </ul>
 
             <h3 className="mt-10 text-base font-semibold text-[#ECECEC]">cURL</h3>
-            <CodeBlock>{`curl -sS -X POST "${BASE}/api/optimize-sync" \\
+            <DocsCodeBlock>{`curl -sS -X POST "${BASE}/api/optimize-sync" \\
   -H "Content-Type: application/json" \\
   -d '{
     "text": "Write me something about our product.",
     "mode": "better",
     "provider": "gemini"
-  }'`}</CodeBlock>
+  }'`}</DocsCodeBlock>
             <p className="mt-2 text-xs text-zinc-500">With BYOK via header:</p>
-            <CodeBlock>{`curl -sS -X POST "${BASE}/api/optimize-sync" \\
+            <DocsCodeBlock>{`curl -sS -X POST "${BASE}/api/optimize-sync" \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_GEMINI_OR_OPENAI_KEY" \\
-  -d '{"text":"Summarize this email in 3 bullets.","mode":"specific","provider":"openai"}'`}</CodeBlock>
+  -d '{"text":"Summarize this email in 3 bullets.","mode":"specific","provider":"openai"}'`}</DocsCodeBlock>
 
             <h3 className="mt-10 text-base font-semibold text-[#ECECEC]">JavaScript</h3>
-            <CodeBlock>{`const res = await fetch(\`${BASE}/api/optimize-sync\`, {
+            <DocsCodeBlock>{`const res = await fetch(\`${BASE}/api/optimize-sync\`, {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -275,10 +269,10 @@ if (!res.ok) {
 }
 
 const data = await res.json();
-console.log(data.optimizedText, data.explanation, data.changes);`}</CodeBlock>
+console.log(data.optimizedText, data.explanation, data.changes);`}</DocsCodeBlock>
 
             <h3 className="mt-10 text-base font-semibold text-[#ECECEC]">Python</h3>
-            <CodeBlock>{`import requests
+            <DocsCodeBlock>{`import requests
 
 url = "${BASE}/api/optimize-sync"
 payload = {
@@ -295,7 +289,7 @@ r.raise_for_status()
 data = r.json()
 print(data["optimizedText"])
 print(data["explanation"])
-print(data["changes"])`}</CodeBlock>
+print(data["changes"])`}</DocsCodeBlock>
           </section>
 
           <section id="modes" className="scroll-mt-6">
@@ -308,24 +302,24 @@ print(data["changes"])`}</CodeBlock>
             <ul className="mt-4 space-y-4 text-sm leading-relaxed text-zinc-300">
               <li className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
                 <span className="font-mono text-[#4552FF]">better</span>
-                <p className="mt-2 text-zinc-400">
+                <div className="mt-2 text-zinc-400">
                   General upgrade: clearer, more effective wording while keeping the user&apos;s intent.
                   Good default when you are not sure which lens to use.
-                </p>
+                </div>
               </li>
               <li className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
                 <span className="font-mono text-[#4552FF]">specific</span>
-                <p className="mt-2 text-zinc-400">
+                <div className="mt-2 text-zinc-400">
                   Pushes for constraints, audience, format, success criteria, edge cases, and measurable
                   outcomes so the model has less room to guess.
-                </p>
+                </div>
               </li>
               <li className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-4">
                 <span className="font-mono text-[#4552FF]">cot</span>
-                <p className="mt-2 text-zinc-400">
+                <div className="mt-2 text-zinc-400">
                   Chain-of-thought style: encourages step-by-step reasoning, checking intermediate
                   steps, or &quot;think through X before Y&quot; without pointless bloat.
-                </p>
+                </div>
               </li>
             </ul>
             <p className="mt-6 text-sm text-zinc-500">

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/client/supabaseBrowser';
+import { buildPasswordResetRedirectUrl } from '@/lib/auth/passwordResetRedirect';
 import { AuthShell } from '@/components/auth/AuthShell';
 import {
   authInputClass,
@@ -14,18 +16,39 @@ export default function ForgotPasswordPage() {
   const [sent, setSent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [cooldownSec, setCooldownSec] = useState(0);
+  const [recoveryLink, setRecoveryLink] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(true);
+  const [googleHint, setGoogleHint] = useState<string | null>(null);
 
-  const configured = useMemo(() => {
-    return Boolean(
-      process.env.NEXT_PUBLIC_SUPABASE_URL &&
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-    );
-  }, []);
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+  const configured = useMemo(() => Boolean(supabase), [supabase]);
+  const isLocalhost =
+    typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1');
+
+  useEffect(() => {
+    if (cooldownSec <= 0) return;
+    const t = window.setInterval(() => {
+      setCooldownSec((s) => (s <= 1 ? 0 : s - 1));
+    }, 1000);
+    return () => window.clearInterval(t);
+  }, [cooldownSec]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError('');
-    if (!configured) {
+    setRecoveryLink(null);
+    setGoogleHint(null);
+
+    if (cooldownSec > 0) {
+      setError(
+        `Please wait ${cooldownSec} seconds before requesting another reset.`,
+      );
+      return;
+    }
+    if (!configured || !supabase) {
       setError('Supabase is not configured');
       return;
     }
@@ -35,26 +58,44 @@ export default function ForgotPasswordPage() {
       return;
     }
 
+    const redirectTo =
+      typeof window !== 'undefined'
+        ? buildPasswordResetRedirectUrl(window.location.origin)
+        : undefined;
+
     setLoading(true);
     try {
       const res = await fetch('/api/auth/forgot-password', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: trimmed }),
+        body: JSON.stringify({ email: trimmed, redirectTo }),
       });
       const data = (await res.json()) as {
         error?: string;
         hint?: string;
         code?: string;
+        ok?: boolean;
+        emailSent?: boolean;
+        recoveryLink?: string;
+        message?: string;
+        googleOnlyHint?: string;
       };
 
       if (!res.ok) {
+        if (data.code === 'EMAIL_RATE_LIMIT') {
+          const secMatch = data.error?.match(/Wait (\d+) seconds/i);
+          setCooldownSec(secMatch ? Number(secMatch[1]) : 60);
+        }
         const parts = [data.error || 'Something went wrong'];
         if (data.hint) parts.push(data.hint);
         setError(parts.join(' '));
         return;
       }
 
+      if (data.googleOnlyHint) setGoogleHint(data.googleOnlyHint);
+      setEmailSent(data.emailSent !== false);
+      if (data.recoveryLink) setRecoveryLink(data.recoveryLink);
+      if (data.message && !data.emailSent) setError(data.message);
       setSent(true);
     } finally {
       setLoading(false);
@@ -101,10 +142,14 @@ export default function ForgotPasswordPage() {
             )}
             <button
               type="submit"
-              disabled={loading}
+              disabled={loading || cooldownSec > 0}
               className={authPrimaryBtnClass}
             >
-              {loading ? 'Sending…' : 'Send reset link'}
+              {loading
+                ? 'Sending…'
+                : cooldownSec > 0
+                  ? `Wait ${cooldownSec}s…`
+                  : 'Send reset link'}
             </button>
           </form>
         </>
@@ -117,13 +162,45 @@ export default function ForgotPasswordPage() {
             ✓
           </div>
           <h1 className="text-center font-heading text-2xl font-semibold tracking-tight text-[#E7E6D9]">
-            Check your email
+            {emailSent ? 'Check your email' : 'Reset link ready'}
           </h1>
-          <p className="mt-3 text-center text-sm leading-relaxed text-[#B0B0B0]">
-            We sent a password reset link to{' '}
-            <span className="font-medium text-[#E7E6D9]">{email.trim()}</span>.
-            Open it to choose a new password (link expires after a while).
-          </p>
+          {emailSent ? (
+            <p className="mt-3 text-center text-sm leading-relaxed text-[#B0B0B0]">
+              We sent a password reset link to{' '}
+              <span className="font-medium text-[#E7E6D9]">{email.trim()}</span>.
+              Open it to choose a new password (check spam too).
+            </p>
+          ) : (
+            <p className="mt-3 text-center text-sm leading-relaxed text-[#B0B0B0]">
+              Supabase did not send another email (rate limit or mail delay). On
+              localhost you can use the direct link below instead.
+            </p>
+          )}
+          {error && (
+            <p className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-center text-sm text-amber-200">
+              {error}
+            </p>
+          )}
+          {googleHint && (
+            <p className="mt-3 text-center text-sm text-[#B0B0B0]">{googleHint}</p>
+          )}
+          {recoveryLink && isLocalhost && (
+            <div className="mt-4 rounded-lg border border-[#4552FF]/30 bg-[#4552FF]/10 p-4">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wide text-[#71717A]">
+                Local dev — direct reset link
+              </p>
+              <a
+                href={recoveryLink}
+                className="break-all text-sm text-[#4552FF] hover:underline"
+              >
+                Open password reset link
+              </a>
+              <p className="mt-2 text-xs text-[#71717A]">
+                Use this when Supabase email does not arrive. Link expires after
+                a short time.
+              </p>
+            </div>
+          )}
           <Link
             href="/login"
             className={`${authPrimaryBtnClass} mt-8 block text-center no-underline`}

--- a/src/components/DocsCodeBlock.tsx
+++ b/src/components/DocsCodeBlock.tsx
@@ -1,0 +1,19 @@
+/**
+ * Static code sample for /docs. Uses <figure> (never nested in <p>) and
+ * suppressHydrationWarning on <pre> so browser extensions (Grammarly, etc.)
+ * that wrap code blocks do not trigger hydration mismatches.
+ */
+export function DocsCodeBlock({ children }: { children: string }) {
+  return (
+    <figure className="not-prose mt-3">
+      <pre
+        suppressHydrationWarning
+        className="overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 p-3 text-left text-[12px] leading-relaxed text-zinc-200 sm:p-4 sm:text-[13px]"
+      >
+        <code suppressHydrationWarning className="font-mono whitespace-pre">
+          {children}
+        </code>
+      </pre>
+    </figure>
+  );
+}

--- a/src/lib/auth/passwordResetRedirect.test.ts
+++ b/src/lib/auth/passwordResetRedirect.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPasswordResetRedirectUrl,
+  mapPasswordResetEmailError,
+  resolvePasswordResetRedirect,
+} from './passwordResetRedirect';
+
+describe('passwordResetRedirect', () => {
+  it('builds /auth/reset from origin', () => {
+    expect(buildPasswordResetRedirectUrl('http://localhost:3000')).toBe(
+      'http://localhost:3000/auth/reset',
+    );
+  });
+
+  it('prefers validated client redirectTo', () => {
+    const req = new Request('http://localhost:3000/api/auth/forgot-password', {
+      headers: { host: 'localhost:3000' },
+    });
+    expect(
+      resolvePasswordResetRedirect(
+        req,
+        'http://localhost:3000/auth/reset',
+      ),
+    ).toBe('http://localhost:3000/auth/reset');
+  });
+
+  it('maps Supabase security cooldown errors', () => {
+    const { code, error } = mapPasswordResetEmailError(
+      'For security purposes, you can only request this after 59 seconds.',
+      'http://localhost:3000/auth/reset',
+    );
+    expect(code).toBe('EMAIL_RATE_LIMIT');
+    expect(error).toMatch(/59 seconds/i);
+    expect(error).toMatch(/inbox/i);
+  });
+
+  it('maps redirect allowlist errors', () => {
+    const { code, error } = mapPasswordResetEmailError(
+      'redirect url is not allowed',
+      'http://localhost:3000/auth/reset',
+    );
+    expect(code).toBe('REDIRECT_NOT_ALLOWLISTED');
+    expect(error).toContain('http://localhost:3000/auth/reset');
+  });
+});

--- a/src/lib/auth/passwordResetRedirect.ts
+++ b/src/lib/auth/passwordResetRedirect.ts
@@ -1,0 +1,97 @@
+/**
+ * Build and validate password-recovery redirect URLs for Supabase allowlist.
+ */
+export function buildPasswordResetRedirectUrl(origin: string): string {
+  return `${origin.replace(/\/$/, '')}/auth/reset`;
+}
+
+/** Client may suggest redirectTo; it must match the API request origin. */
+export function resolvePasswordResetRedirect(
+  request: Request,
+  clientRedirectTo?: string,
+): string {
+  const host =
+    request.headers.get('x-forwarded-host')?.split(',')[0]?.trim() ||
+    request.headers.get('host')?.split(',')[0]?.trim();
+  const proto =
+    request.headers.get('x-forwarded-proto')?.split(',')[0]?.trim() || 'http';
+  const requestOrigin = host ? `${proto}://${host}` : null;
+
+  if (clientRedirectTo?.trim()) {
+    try {
+      const parsed = new URL(clientRedirectTo.trim());
+      if (requestOrigin) {
+        const expected = new URL(requestOrigin);
+        if (
+          parsed.protocol === expected.protocol &&
+          parsed.host === expected.host &&
+          parsed.pathname === '/auth/reset'
+        ) {
+          return parsed.origin + parsed.pathname;
+        }
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  if (requestOrigin) {
+    return buildPasswordResetRedirectUrl(requestOrigin);
+  }
+
+  const env = process.env.NEXT_PUBLIC_SITE_URL?.trim().replace(/\/$/, '');
+  if (env) return buildPasswordResetRedirectUrl(env);
+
+  return buildPasswordResetRedirectUrl('http://localhost:3000');
+}
+
+export function mapPasswordResetEmailError(
+  message: string,
+  redirectTo: string,
+): { error: string; code: string } {
+  const lower = message.toLowerCase();
+
+  if (/redirect|url|allowlist|not allowed|invalid.*redirect/i.test(lower)) {
+    return {
+      code: 'REDIRECT_NOT_ALLOWLISTED',
+      error: `Add this URL in Supabase → Authentication → URL Configuration → Redirect URLs: ${redirectTo}`,
+    };
+  }
+
+  if (
+    /rate limit|too many|email.*limit|over_email_send|security purposes|only request this after/i.test(
+      lower,
+    )
+  ) {
+    const secMatch = message.match(/after\s+(\d+)\s+seconds?/i);
+    const waitSec = secMatch ? Number(secMatch[1]) : 60;
+    return {
+      code: 'EMAIL_RATE_LIMIT',
+      error: `You already requested a reset link. Wait ${waitSec} seconds and try again (Supabase allows about one reset email per minute per address). Check your inbox and spam folder first — the last email may already be there.`,
+    };
+  }
+
+  if (/smtp|mail|email.*provider|send.*email|not configured/i.test(lower)) {
+    return {
+      code: 'EMAIL_NOT_CONFIGURED',
+      error:
+        'Password reset email is not configured. In Supabase Dashboard → Project Settings → Authentication, enable email (or set up custom SMTP).',
+    };
+  }
+
+  if (/user not found|not found|no user/i.test(lower)) {
+    return {
+      code: 'ACCOUNT_NOT_FOUND',
+      error:
+        'No account exists for this email address. Check spelling or create an account.',
+    };
+  }
+
+  return {
+    code: 'RESET_EMAIL_FAILED',
+    error:
+      process.env.NODE_ENV === 'production'
+        ? 'Could not send reset email. Please try again later.'
+        : `Could not send reset email: ${message}`,
+  };
+}


### PR DESCRIPTION
Forgot-password API returns localhost recovery links when email is rate-limited; reset page exchanges code for session. Extension v1.2 requires BYOK, limits content scripts to supported sites, and surfaces clearer API errors. Docs use DocsCodeBlock to avoid hydration mismatches.

## What I Built
[Brief description of the feature or fix]

## How to Test
[Step-by-step instructions to test this PR locally]

## Screenshots
[If UI changes, add before/after screenshots]

## Checklist
- [ ] Tests pass locally (`npm test` or `pytest`)
- [ ] No hardcoded API keys or secrets
- [ ] Commit messages follow conventional format (feat:/fix:/test:/docs:)
- [ ] Posted PR link in team Discord channel
