### PR TITLE
fix: production build — narrow Supabase client in password reset page

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -124,7 +124,7 @@ export async function POST(request: Request) {
   const identities = linkData.user.identities ?? [];
   const signedUpWithGoogleOnly =
     identities.length > 0 &&
-    identities.every((i) => i.provider === 'google');
+    identities.every((i: { provider?: string }) => i.provider === 'google');
 
   const anon = createClient(url, anonKey, {
     auth: {

--- a/src/app/auth/reset/page.tsx
+++ b/src/app/auth/reset/page.tsx
@@ -24,17 +24,24 @@ export default function AuthResetPage() {
   const supabase = useMemo(() => createSupabaseBrowserClient(), []);
 
   useEffect(() => {
-    if (!supabase) return;
+    const client = supabase;
+    if (!client) return;
 
     let cancelled = false;
 
     async function initRecoverySession() {
+      const authClient = client;
+      if (!authClient) {
+        if (!cancelled) setSessionReady(true);
+        return;
+      }
+
       const params = new URLSearchParams(window.location.search);
       const code = params.get('code');
 
       if (code) {
         const { error: exchangeErr } =
-          await supabase.auth.exchangeCodeForSession(code);
+          await authClient.auth.exchangeCodeForSession(code);
         if (!cancelled && exchangeErr) {
           setError(
             'This reset link is invalid or expired. Request a new link from the forgot-password page.',
@@ -46,7 +53,7 @@ export default function AuthResetPage() {
 
       const {
         data: { session },
-      } = await supabase.auth.getSession();
+      } = await authClient.auth.getSession();
 
       if (!cancelled && !session) {
         setError(


### PR DESCRIPTION
## What I Built
[Brief description of the feature or fix]

## How to Test
[Step-by-step instructions to test this PR locally]

## Screenshots
[If UI changes, add before/after screenshots]

## Checklist
- [ ] Tests pass locally (`npm test` or `pytest`)
- [ ] No hardcoded API keys or secrets
- [ ] Commit messages follow conventional format (feat:/fix:/test:/docs:)
- [ ] Posted PR link in team Discord channel
